### PR TITLE
fix(deploy): use new_sqlite_classes for RaidRoom DO on free plan

### DIFF
--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -41,4 +41,4 @@ id = "f2854b63af57469b953be1881492ab9b"
 # Add DO migration entry
 [[migrations]]
 tag = "v1-add-raid-rooms"
-new_classes = ["RaidRoom"]
+new_sqlite_classes = ["RaidRoom"]


### PR DESCRIPTION
## Summary

Production deploy of #32 failed with Cloudflare API error 10097:

> In order to use Durable Objects with a free plan, you must create a namespace using a \`new_sqlite_classes\` migration.

The post-merge CD run on \`main\` ([26498907137](https://github.com/RievoCante/typing-rpg/actions/runs/26498907137)) uploaded the Worker successfully but the deploy step rejected the migration declaration because the free Cloudflare plan only supports SQLite-backed DOs.

One-line fix in \`backend/wrangler.toml\`:

\`\`\`diff
 [[migrations]]
 tag = "v1-add-raid-rooms"
-new_classes = ["RaidRoom"]
+new_sqlite_classes = ["RaidRoom"]
\`\`\`

## Current prod state (pre-fix)

- ✅ D1 schema already updated (raid_rooms, raid_sessions, raid_players, xp_awarded — applied successfully in the failed run's earlier migration step)
- ❌ Worker code is **still pre-raid** (deploy never landed). Schema-code mismatch is benign (old code doesn't query new tables) but raid feature is dark.

## Risk

The migration tag \`v1-add-raid-rooms\` may have been partially registered on Cloudflare's side with the failed \`new_classes\` declaration. If Cloudflare rejects re-declaring the same tag with different class type, we'll need to add a new migration tag (\`v2-raid-rooms-sqlite\`) as a follow-up. We'll know from the next CD run.

## Test Plan

- [x] Backend: \`bun test\` — 37/37 passing (no behavior change; config-only edit)
- [ ] **Post-merge**: confirm CD run on main succeeds (\`gh run list --branch main --limit 1\`)
- [ ] **Post-deploy**: open prod URL in 2 tabs, create a raid, join, start, confirm the WebSocket connects to the live RaidRoom DO

🤖 Generated with [Claude Code](https://claude.com/claude-code)