### PR TITLE
feat(raid): auto-start 5s countdown when room fills to 3 players

### DIFF
--- a/backend/src/rooms/RaidRoom.test.ts
+++ b/backend/src/rooms/RaidRoom.test.ts
@@ -20,12 +20,11 @@ describe('RaidRoom', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     // Clear any pending timers from the room instance
-    if ((room as any).state?.attackTimer) {
-      clearInterval((room as any).state.attackTimer);
-    }
-    if ((room as any).state?.graceTimer) {
-      clearTimeout((room as any).state.graceTimer);
-    }
+    const s = (room as any).state;
+    if (s?.attackTimer) clearInterval(s.attackTimer);
+    if (s?.graceTimer) clearTimeout(s.graceTimer);
+    if (s?.countdownTimer) clearTimeout(s.countdownTimer);
+    vi.useRealTimers();
   });
 
   it('starts in lobby phase', () => {
@@ -182,7 +181,8 @@ describe('RaidRoom', () => {
     (room as any).handlePlayerJoin(ws, { userId: 'u1', username: 'Alice' });
     (room as any).handlePlayerJoin(ws2, { userId: 'u2', username: 'Bob' });
     (room as any).handlePlayerJoin(ws3, { userId: 'u3', username: 'Charlie' });
-    (room as any).handleStartGame(ws);
+    // 3 players auto-enter countdown; start the raid directly for this unit test.
+    (room as any).beginRaid();
     // Kill Charlie so we can verify only alive players are hit
     (room as any).state.players.get(ws3).isAlive = false;
     (room as any).state.players.get(ws3).hp = 0;
@@ -339,6 +339,48 @@ describe('RaidRoom', () => {
     (room as any).handlePlayerJoin(ws, { userId: 'u1', username: 'Alice' });
     (room as any).webSocketClose(ws);
     expect((room as any).wsCredentials.has(ws)).toBe(false);
+  });
+
+  // ── Auto-start countdown ──
+
+  describe('auto-start countdown', () => {
+    it('enters countdown phase and broadcasts countdown_started when the 3rd player joins', () => {
+      vi.useFakeTimers();
+      const ws1 = { send: vi.fn() } as any;
+      const ws2 = { send: vi.fn() } as any;
+      const ws3 = { send: vi.fn() } as any;
+      (room as any).handlePlayerJoin(ws1, { userId: 'u1', username: 'Alice' });
+      (room as any).handlePlayerJoin(ws2, { userId: 'u2', username: 'Bob' });
+      expect((room as any).state.phase).toBe('lobby');
+      (room as any).handlePlayerJoin(ws3, { userId: 'u3', username: 'Cara' });
+      expect((room as any).state.phase).toBe('countdown');
+      expect(ws3.send).toHaveBeenCalledWith(
+        expect.stringContaining('"type":"countdown_started"')
+      );
+    });
+
+    it('begins the raid automatically after COUNTDOWN_MS (5s)', () => {
+      vi.useFakeTimers();
+      const ws1 = { send: vi.fn() } as any;
+      const ws2 = { send: vi.fn() } as any;
+      const ws3 = { send: vi.fn() } as any;
+      (room as any).handlePlayerJoin(ws1, { userId: 'u1', username: 'Alice' });
+      (room as any).handlePlayerJoin(ws2, { userId: 'u2', username: 'Bob' });
+      (room as any).handlePlayerJoin(ws3, { userId: 'u3', username: 'Cara' });
+      expect((room as any).state.phase).toBe('countdown');
+      vi.advanceTimersByTime(5000);
+      expect((room as any).state.phase).toBe('playing');
+    });
+
+    it('manual 2-player start begins immediately with no countdown', () => {
+      const ws1 = { send: vi.fn() } as any;
+      const ws2 = { send: vi.fn() } as any;
+      (room as any).handlePlayerJoin(ws1, { userId: 'u1', username: 'Alice' });
+      (room as any).handlePlayerJoin(ws2, { userId: 'u2', username: 'Bob' });
+      (room as any).handleStartGame(ws1);
+      expect((room as any).state.phase).toBe('playing');
+      expect((room as any).state.countdownTimer).toBeNull();
+    });
   });
 
   // ── webSocketError regression test ──

--- a/backend/src/rooms/RaidRoom.test.ts
+++ b/backend/src/rooms/RaidRoom.test.ts
@@ -383,6 +383,51 @@ describe('RaidRoom', () => {
     });
   });
 
+  // ── Countdown cancellation ──
+
+  describe('countdown cancellation', () => {
+    it('cancels the countdown and returns to lobby when a player drops below 3', () => {
+      vi.useFakeTimers();
+      const ws1 = { send: vi.fn() } as any;
+      const ws2 = { send: vi.fn() } as any;
+      const ws3 = { send: vi.fn() } as any;
+      (room as any).handlePlayerJoin(ws1, { userId: 'u1', username: 'Alice' });
+      (room as any).handlePlayerJoin(ws2, { userId: 'u2', username: 'Bob' });
+      (room as any).handlePlayerJoin(ws3, { userId: 'u3', username: 'Cara' });
+      expect((room as any).state.phase).toBe('countdown');
+
+      (room as any).webSocketClose(ws3);
+
+      expect((room as any).state.phase).toBe('lobby');
+      expect((room as any).state.countdownTimer).toBeNull();
+      expect((room as any).state.players.size).toBe(2);
+      expect(ws1.send).toHaveBeenCalledWith(
+        expect.stringContaining('"type":"countdown_cancelled"')
+      );
+
+      // The cleared timer must not fire a late beginRaid.
+      vi.advanceTimersByTime(5000);
+      expect((room as any).state.phase).toBe('lobby');
+    });
+
+    it('reassigns host when the host leaves during the countdown', () => {
+      vi.useFakeTimers();
+      const ws1 = { send: vi.fn() } as any;
+      const ws2 = { send: vi.fn() } as any;
+      const ws3 = { send: vi.fn() } as any;
+      (room as any).handlePlayerJoin(ws1, { userId: 'u1', username: 'Alice' });
+      (room as any).handlePlayerJoin(ws2, { userId: 'u2', username: 'Bob' });
+      (room as any).handlePlayerJoin(ws3, { userId: 'u3', username: 'Cara' });
+      expect((room as any).state.players.get(ws1).isHost).toBe(true);
+
+      (room as any).webSocketClose(ws1); // host leaves during countdown
+
+      expect((room as any).state.phase).toBe('lobby');
+      const remaining = Array.from((room as any).state.players.values()) as any[];
+      expect(remaining.some(p => p.isHost)).toBe(true);
+    });
+  });
+
   // ── webSocketError regression test ──
 
   it('removes player on webSocketError and transfers host in lobby', () => {

--- a/backend/src/rooms/RaidRoom.ts
+++ b/backend/src/rooms/RaidRoom.ts
@@ -283,6 +283,12 @@ export class RaidRoom extends DurableObject {
 
     this.broadcastRoomState();
     this.broadcast({ type: 'player_joined', userId: data.userId, username: data.username, characterConfig: config });
+
+    // Auto-start: once the room fills to MAX_PLAYERS, kick off a countdown that
+    // fires beginRaid() — no host action needed.
+    if (this.state.phase === 'lobby' && this.state.players.size === MAX_PLAYERS) {
+      this.startCountdown();
+    }
   }
 
   async createRoomInDb(hostId: string, hostUsername: string) {
@@ -410,6 +416,14 @@ export class RaidRoom extends DurableObject {
     this.syncPlayerCountToDb(this.state.players.size, 'active');
 
     this.state.attackTimer = setInterval(() => this.bossAttack(), BOSS_ATTACK_INTERVAL_MS);
+  }
+
+  private startCountdown() {
+    this.state.phase = 'countdown';
+    this.state.countdownEndsAt = Date.now() + COUNTDOWN_MS;
+    this.broadcast({ type: 'countdown_started', durationMs: COUNTDOWN_MS });
+    this.broadcastRoomState();
+    this.state.countdownTimer = setTimeout(() => this.beginRaid(), COUNTDOWN_MS);
   }
 
   handleWordComplete(ws: WebSocket, _data: { wordIndex: number }) {
@@ -677,6 +691,9 @@ export class RaidRoom extends DurableObject {
       bossHp: this.state.bossHp,
       bossMaxHp: this.state.bossMaxHp,
     };
+    if (this.state.phase === 'countdown' && this.state.countdownEndsAt != null) {
+      state.countdownEndsAt = this.state.countdownEndsAt;
+    }
     if (extra?.result) state.result = extra.result;
     if (extra?.stats) state.stats = extra.stats;
 

--- a/backend/src/rooms/RaidRoom.ts
+++ b/backend/src/rooms/RaidRoom.ts
@@ -426,6 +426,16 @@ export class RaidRoom extends DurableObject {
     this.state.countdownTimer = setTimeout(() => this.beginRaid(), COUNTDOWN_MS);
   }
 
+  private cancelCountdown() {
+    if (this.state.countdownTimer) {
+      clearTimeout(this.state.countdownTimer);
+      this.state.countdownTimer = null;
+    }
+    this.state.countdownEndsAt = null;
+    this.state.phase = 'lobby';
+    this.broadcast({ type: 'countdown_cancelled' });
+  }
+
   handleWordComplete(ws: WebSocket, _data: { wordIndex: number }) {
     if (this.state.phase !== 'playing') return;
     const player = this.state.players.get(ws);
@@ -726,6 +736,15 @@ export class RaidRoom extends DurableObject {
       clearTimeout(this.state.graceTimer);
       this.state.graceTimer = null;
     }
+
+    // If a player drops during the auto-start countdown and we fall below the
+    // full-room threshold, cancel the countdown and return everyone to the
+    // lobby. Setting phase back to 'lobby' here also lets the existing
+    // host-reassignment block below run for a host who left mid-countdown.
+    if (this.state.phase === 'countdown' && this.state.players.size < MAX_PLAYERS) {
+      this.cancelCountdown();
+    }
+
     let newHostId: string | undefined;
     let newHostUsername: string | undefined;
 

--- a/backend/src/rooms/RaidRoom.ts
+++ b/backend/src/rooms/RaidRoom.ts
@@ -20,7 +20,7 @@ type PlayerState = {
   characterConfig: CharacterConfig | null;
 };
 
-type RoomPhase = 'lobby' | 'playing' | 'finished';
+type RoomPhase = 'lobby' | 'countdown' | 'playing' | 'finished';
 
 type RaidRoomState = {
   phase: RoomPhase;
@@ -37,6 +37,8 @@ type RaidRoomState = {
   attackTimer: ReturnType<typeof setInterval> | null;
   graceTimer: ReturnType<typeof setTimeout> | null;
   idleTimer: ReturnType<typeof setTimeout> | null;
+  countdownTimer: ReturnType<typeof setTimeout> | null;
+  countdownEndsAt: number | null;
   dbRoomCreated: boolean;
 };
 
@@ -52,6 +54,7 @@ const MISTAKE_DAMAGE_MAX = 15;
 const PLAYER_MAX_HP = 100;
 const ROOM_IDLE_TIMEOUT_MS = 300_000;
 const GRACE_PERIOD_MS = 30_000;
+const COUNTDOWN_MS = 5_000;
 
 const WORDS: string[] = (english1k as { words: string[] }).words;
 
@@ -104,6 +107,8 @@ export class RaidRoom extends DurableObject {
       attackTimer: null,
       graceTimer: null,
       idleTimer: null,
+      countdownTimer: null,
+      countdownEndsAt: null,
       dbRoomCreated: false,
     };
   }
@@ -370,7 +375,19 @@ export class RaidRoom extends DurableObject {
       return;
     }
 
+    // Manual start (2-player path) begins immediately — no countdown.
+    this.beginRaid();
+  }
+
+  // The actual raid kickoff. Called by the host's manual start (2 players) and
+  // by the auto-start countdown timer when the room fills to MAX_PLAYERS.
+  private beginRaid() {
     this.clearIdleTimer();
+    if (this.state.countdownTimer) {
+      clearTimeout(this.state.countdownTimer);
+      this.state.countdownTimer = null;
+    }
+    this.state.countdownEndsAt = null;
 
     this.state.bossMaxHp = BOSS_MAX_HP;
     this.state.bossHp = BOSS_MAX_HP;
@@ -390,7 +407,7 @@ export class RaidRoom extends DurableObject {
     this.broadcastRoomState();
 
     // Sync final player count and mark room as active so it disappears from lobby
-    this.syncPlayerCountToDb(playerCount, 'active');
+    this.syncPlayerCountToDb(this.state.players.size, 'active');
 
     this.state.attackTimer = setInterval(() => this.bossAttack(), BOSS_ATTACK_INTERVAL_MS);
   }

--- a/frontend/src/components/RaidCountdownOverlay.test.ts
+++ b/frontend/src/components/RaidCountdownOverlay.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { countdownRemaining } from './RaidCountdownOverlay';
+
+describe('countdownRemaining', () => {
+  it('rounds up to whole seconds remaining', () => {
+    expect(countdownRemaining(10_000, 5_500)).toBe(5); // 4.5s -> ceil 5
+    expect(countdownRemaining(10_000, 6_000)).toBe(4);
+  });
+
+  it('returns 0 at or past the end (never negative)', () => {
+    expect(countdownRemaining(5_000, 5_000)).toBe(0);
+    expect(countdownRemaining(1_000, 5_000)).toBe(0);
+  });
+});

--- a/frontend/src/components/RaidCountdownOverlay.tsx
+++ b/frontend/src/components/RaidCountdownOverlay.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+// Whole seconds remaining until `endsAt`, clamped at 0. Pure so it can be
+// unit-tested without a DOM (frontend vitest runs in the node environment).
+export function countdownRemaining(endsAt: number, nowMs: number): number {
+  return Math.max(0, Math.ceil((endsAt - nowMs) / 1000));
+}
+
+interface RaidCountdownOverlayProps {
+  endsAt: number;
+}
+
+// Full-screen "get ready" overlay shown during the auto-start countdown. Ticks
+// locally off `endsAt`; the server's `game_started` is what actually swaps to
+// the game, so any sub-second clock skew is invisible.
+export default function RaidCountdownOverlay({
+  endsAt,
+}: RaidCountdownOverlayProps) {
+  const [remaining, setRemaining] = useState(() =>
+    countdownRemaining(endsAt, Date.now())
+  );
+
+  useEffect(() => {
+    setRemaining(countdownRemaining(endsAt, Date.now()));
+    const id = setInterval(() => {
+      setRemaining(countdownRemaining(endsAt, Date.now()));
+    }, 200);
+    return () => clearInterval(id);
+  }, [endsAt]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/70 backdrop-blur-sm text-white">
+      <p className="mb-4 text-lg uppercase tracking-widest text-gray-300">
+        Room full — get ready
+      </p>
+      <div className="text-8xl font-extrabold tabular-nums animate-pulse">
+        {remaining > 0 ? remaining : 'Starting…'}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/RaidCountdownOverlay.tsx
+++ b/frontend/src/components/RaidCountdownOverlay.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useState } from 'react';
-
-// Whole seconds remaining until `endsAt`, clamped at 0. Pure so it can be
-// unit-tested without a DOM (frontend vitest runs in the node environment).
-export function countdownRemaining(endsAt: number, nowMs: number): number {
-  return Math.max(0, Math.ceil((endsAt - nowMs) / 1000));
-}
+import { countdownRemaining } from '../utils/countdownRemaining';
 
 interface RaidCountdownOverlayProps {
   endsAt: number;
@@ -33,7 +28,10 @@ export default function RaidCountdownOverlay({
       <p className="mb-4 text-lg uppercase tracking-widest text-gray-300">
         Room full — get ready
       </p>
-      <div className="text-8xl font-extrabold tabular-nums animate-pulse">
+      <div
+        aria-live="assertive"
+        className="text-8xl font-extrabold tabular-nums animate-pulse"
+      >
         {remaining > 0 ? remaining : 'Starting…'}
       </div>
     </div>

--- a/frontend/src/components/RaidView.tsx
+++ b/frontend/src/components/RaidView.tsx
@@ -5,6 +5,7 @@ import { useRaidState } from '../hooks/useRaidState';
 import { useGameContext } from '../hooks/useGameContext';
 import { useCharacter } from '../hooks/useCharacter';
 import RaidLobbyScreen from './RaidLobbyScreen';
+import RaidCountdownOverlay from './RaidCountdownOverlay';
 import RaidGame from './RaidGame';
 import RaidResultScreen from './RaidResultScreen';
 
@@ -301,7 +302,7 @@ export default function RaidView() {
 
   return (
     <div className="text-white">
-      {isPhase('lobby') && (
+      {(isPhase('lobby') || isPhase('countdown')) && (
         <RaidLobbyScreen
           roomCode={activeRoomId ?? ''}
           players={state.players}
@@ -310,6 +311,9 @@ export default function RaidView() {
           onLeaveRoom={handleBackToLobby}
           error={state.error}
         />
+      )}
+      {isPhase('countdown') && state.countdownEndsAt != null && (
+        <RaidCountdownOverlay endsAt={state.countdownEndsAt} />
       )}
       {isPhase('playing') && (
         <RaidGame

--- a/frontend/src/hooks/useRaidSocket.ts
+++ b/frontend/src/hooks/useRaidSocket.ts
@@ -41,14 +41,17 @@ export type RaidStats = {
 export type RaidServerMessage =
   | {
       type: 'room_state';
-      phase: 'lobby' | 'playing' | 'finished';
+      phase: 'lobby' | 'countdown' | 'playing' | 'finished';
       players: RaidPlayer[];
       bossHp: number;
       bossMaxHp: number;
+      countdownEndsAt?: number;
       result?: 'victory' | 'defeat';
       stats?: RaidStats;
     }
   | { type: 'game_started'; texts: Record<string, string> }
+  | { type: 'countdown_started'; durationMs: number }
+  | { type: 'countdown_cancelled' }
   | { type: 'player_died'; playerId: string }
   | { type: 'victory'; stats: RaidStats }
   | { type: 'defeat'; stats: RaidStats }

--- a/frontend/src/hooks/useRaidSocket.ts
+++ b/frontend/src/hooks/useRaidSocket.ts
@@ -45,6 +45,7 @@ export type RaidServerMessage =
       players: RaidPlayer[];
       bossHp: number;
       bossMaxHp: number;
+      /** Present only when phase === 'countdown'. Server epoch ms. */
       countdownEndsAt?: number;
       result?: 'victory' | 'defeat';
       stats?: RaidStats;

--- a/frontend/src/hooks/useRaidState.test.ts
+++ b/frontend/src/hooks/useRaidState.test.ts
@@ -283,6 +283,62 @@ describe('applyRaidMessage', () => {
     });
   });
 
+  describe('countdown_started / countdown_cancelled', () => {
+    it('countdown_started enters countdown phase with a future countdownEndsAt', () => {
+      const before = Date.now();
+      const msg: RaidServerMessage = {
+        type: 'countdown_started',
+        durationMs: 5000,
+      };
+      const next = applyRaidMessage(initialRaidState, msg, LOCAL);
+      expect(next.phase).toBe('countdown');
+      expect(next.countdownEndsAt).not.toBeNull();
+      expect(next.countdownEndsAt!).toBeGreaterThanOrEqual(before + 5000);
+    });
+
+    it('countdown_cancelled returns to lobby and clears countdownEndsAt', () => {
+      const start: RaidState = {
+        ...initialRaidState,
+        phase: 'countdown',
+        countdownEndsAt: Date.now() + 5000,
+      };
+      const msg: RaidServerMessage = { type: 'countdown_cancelled' };
+      const next = applyRaidMessage(start, msg, LOCAL);
+      expect(next.phase).toBe('lobby');
+      expect(next.countdownEndsAt).toBeNull();
+    });
+
+    it('room_state carries countdownEndsAt while in countdown', () => {
+      const endsAt = Date.now() + 4000;
+      const msg: RaidServerMessage = {
+        type: 'room_state',
+        phase: 'countdown',
+        players: [mkPlayer()],
+        bossHp: 0,
+        bossMaxHp: 0,
+        countdownEndsAt: endsAt,
+      };
+      const next = applyRaidMessage(initialRaidState, msg, LOCAL);
+      expect(next.phase).toBe('countdown');
+      expect(next.countdownEndsAt).toBe(endsAt);
+    });
+
+    it('game_started clears countdownEndsAt', () => {
+      const start: RaidState = {
+        ...initialRaidState,
+        phase: 'countdown',
+        countdownEndsAt: Date.now() + 5000,
+      };
+      const msg: RaidServerMessage = {
+        type: 'game_started',
+        texts: { [LOCAL]: 'a b' },
+      };
+      const next = applyRaidMessage(start, msg, LOCAL);
+      expect(next.phase).toBe('playing');
+      expect(next.countdownEndsAt).toBeNull();
+    });
+  });
+
   describe('error', () => {
     it('records the error message without touching other state', () => {
       const start: RaidState = {

--- a/frontend/src/hooks/useRaidState.test.ts
+++ b/frontend/src/hooks/useRaidState.test.ts
@@ -294,6 +294,7 @@ describe('applyRaidMessage', () => {
       expect(next.phase).toBe('countdown');
       expect(next.countdownEndsAt).not.toBeNull();
       expect(next.countdownEndsAt!).toBeGreaterThanOrEqual(before + 5000);
+      expect(next.countdownEndsAt!).toBeLessThan(before + 5000 + 1000);
     });
 
     it('countdown_cancelled returns to lobby and clears countdownEndsAt', () => {

--- a/frontend/src/hooks/useRaidState.ts
+++ b/frontend/src/hooks/useRaidState.ts
@@ -106,8 +106,9 @@ export function applyRaidMessage(
       return {
         ...prev,
         phase: 'countdown',
-        // Locally computed from durationMs; a subsequent room_state in 'countdown'
-        // phase overrides this with the authoritative server timestamp on reconnect.
+        // Locally computed from durationMs. The room_state broadcast that the
+        // server sends immediately after countdown_started carries the
+        // authoritative server countdownEndsAt and overrides this value.
         countdownEndsAt: Date.now() + msg.durationMs,
         error: null,
       };

--- a/frontend/src/hooks/useRaidState.ts
+++ b/frontend/src/hooks/useRaidState.ts
@@ -3,7 +3,7 @@ import type { RaidServerMessage, RaidPlayer, RaidStats } from './useRaidSocket';
 
 export type { RaidPlayer } from './useRaidSocket';
 
-export type RaidPhase = 'lobby' | 'playing' | 'finished';
+export type RaidPhase = 'lobby' | 'countdown' | 'playing' | 'finished';
 
 // Per-player hit events for animated popups. Each carries a fresh `id` so
 // consumers can key animations even when the same player is hit multiple
@@ -24,6 +24,7 @@ export type RaidWordHit = {
 
 export type RaidState = {
   phase: RaidPhase;
+  countdownEndsAt: number | null;
   players: RaidPlayer[];
   bossHp: number;
   bossMaxHp: number;
@@ -41,6 +42,7 @@ let wordHitIdSeq = 0;
 
 export const initialRaidState: RaidState = {
   phase: 'lobby',
+  countdownEndsAt: null,
   players: [],
   bossHp: 0,
   bossMaxHp: 0,
@@ -78,6 +80,10 @@ export function applyRaidMessage(
         // render still populates the result screen.
         result: msg.result ?? prev.result,
         stats: msg.stats ?? prev.stats,
+        countdownEndsAt:
+          msg.phase === 'countdown'
+            ? (msg.countdownEndsAt ?? prev.countdownEndsAt)
+            : null,
         // Stale errors should not linger across phases.
         error: null,
       };
@@ -88,12 +94,26 @@ export function applyRaidMessage(
       return {
         ...prev,
         phase: 'playing',
+        countdownEndsAt: null,
         localText: msg.texts?.[localUserId] ?? '',
         result: null,
         stats: null,
         error: null,
         lastHit: null,
         lastWordHit: null,
+      };
+    case 'countdown_started':
+      return {
+        ...prev,
+        phase: 'countdown',
+        countdownEndsAt: Date.now() + msg.durationMs,
+        error: null,
+      };
+    case 'countdown_cancelled':
+      return {
+        ...prev,
+        phase: 'lobby',
+        countdownEndsAt: null,
       };
     case 'word_hit':
       return {

--- a/frontend/src/hooks/useRaidState.ts
+++ b/frontend/src/hooks/useRaidState.ts
@@ -106,6 +106,8 @@ export function applyRaidMessage(
       return {
         ...prev,
         phase: 'countdown',
+        // Locally computed from durationMs; a subsequent room_state in 'countdown'
+        // phase overrides this with the authoritative server timestamp on reconnect.
         countdownEndsAt: Date.now() + msg.durationMs,
         error: null,
       };
@@ -114,6 +116,7 @@ export function applyRaidMessage(
         ...prev,
         phase: 'lobby',
         countdownEndsAt: null,
+        error: null,
       };
     case 'word_hit':
       return {

--- a/frontend/src/utils/countdownRemaining.test.ts
+++ b/frontend/src/utils/countdownRemaining.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { countdownRemaining } from './RaidCountdownOverlay';
+import { countdownRemaining } from './countdownRemaining';
 
 describe('countdownRemaining', () => {
   it('rounds up to whole seconds remaining', () => {

--- a/frontend/src/utils/countdownRemaining.ts
+++ b/frontend/src/utils/countdownRemaining.ts
@@ -1,0 +1,5 @@
+// Whole seconds remaining until `endsAt`, clamped at 0. Pure so it can be
+// unit-tested without a DOM (frontend vitest runs in the node environment).
+export function countdownRemaining(endsAt: number, nowMs: number): number {
+  return Math.max(0, Math.ceil((endsAt - nowMs) / 1000));
+}


### PR DESCRIPTION
## What

Auto-starts a raid once the room fills to **3 players (MAX_PLAYERS)** via a server-authoritative **5-second countdown** visible to all clients. Manual **2-player** start stays instant (unchanged host button).

Server is the source of truth: the DO arms an in-memory `setTimeout(beginRaid, 5000)` on the 3rd join and broadcasts `countdown_started` (+ `countdownEndsAt` on `room_state`). If a player leaves during the countdown, it cancels and returns the room to `lobby` (`countdown_cancelled`).

## How it lands here

Cherry-picked the **8 implementation commits** (`f340a7d..1c32439`, originally `001e315..260c2c2`) onto current `dev` — deliberately **excluding** the spec/plan docs and the duplicate #35 avatar commit that `dev` already has, to avoid spurious conflicts.

One real conflict in `backend/src/rooms/RaidRoom.ts`: `dev` adds `characterConfig` to the `player_joined` broadcast (customizer feature) while this branch adds the auto-start block — both kept, they're independent.

The countdown UI wiring slots cleanly into the **renovated** `RaidView`: `lobby` + `countdown` both mount `RaidLobbyScreen`, and `countdown` additionally overlays `RaidCountdownOverlay`.

## Changes

- **Backend** (`RaidRoom.ts`): `countdown` phase, `countdownTimer`/`countdownEndsAt` state, `COUNTDOWN_MS=5000`, extracted `beginRaid()`, `startCountdown()` on 3rd join, `cancelCountdown()` on leave-during-countdown (preserves host reassignment).
- **Frontend**: `countdown_started`/`countdown_cancelled` messages + `countdownEndsAt` in `useRaidSocket`/`useRaidState`; new `RaidCountdownOverlay.tsx` + pure `utils/countdownRemaining.ts`; `RaidView` overlay wiring (`aria-live`).

## Verification (CI, all green on this branch)

- **Backend**: `tsc --noEmit` clean · `bun run test` **63/63** pass
- **Frontend**: `lint` 0 errors (3 pre-existing warnings, unrelated) · `format:check` clean · `tsc` clean · `bun run test` **66/66** pass · `build` ok

## Manual QA gate (cannot be unit-tested — please run on the dev deploy)

- [ ] 2-player manual start still instant
- [ ] 3rd join → all 3 see the 5s overlay, then start together
- [ ] A player leaving during countdown cancels it on the remaining clients
- [ ] Host leaves during countdown → host reassignment still works
- [ ] **Renovation regression**: confirm the overlay renders correctly over the new renovated raid UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)